### PR TITLE
fix: set DynamoDB table removal policy to Destroy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,6 @@ export interface SemaphoreProps {
    * @default PAY_PER_REQUEST
    */
   readonly tableReadWriteCapacity?: TableReadWriteCapacity;
-  readonly tableRemovalPolicy?: RemovalPolicy;
 }
 
 /**
@@ -243,7 +242,7 @@ export class Semaphore extends StateMachineFragment {
         readCapacity: props.tableReadWriteCapacity?.readCapacity,
         writeCapacity: props.tableReadWriteCapacity?.writeCapacity,
         billingMode: props.tableReadWriteCapacity ? BillingMode.PROVISIONED : BillingMode.PAY_PER_REQUEST,
-        removalPolicy: props.tableRemovalPolicy ?? RemovalPolicy.DESTROY,
+        removalPolicy: RemovalPolicy.DESTROY,
       });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Duration, Names, Stack } from 'aws-cdk-lib';
+import { Duration, Names, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Table, BillingMode, AttributeType } from 'aws-cdk-lib/aws-dynamodb';
 import { Parallel, StateMachineFragment, JsonPath, Choice, Pass, Wait, WaitTime, Condition, State, IChainable, INextable } from 'aws-cdk-lib/aws-stepfunctions';
 import { DynamoAttributeValue, DynamoGetItem, DynamoProjectionExpression, DynamoPutItem, DynamoReturnValues, DynamoUpdateItem } from 'aws-cdk-lib/aws-stepfunctions-tasks';
@@ -39,6 +39,7 @@ export interface SemaphoreProps {
    * @default PAY_PER_REQUEST
    */
   readonly tableReadWriteCapacity?: TableReadWriteCapacity;
+  readonly tableRemovalPolicy?: RemovalPolicy;
 }
 
 /**
@@ -242,6 +243,7 @@ export class Semaphore extends StateMachineFragment {
         readCapacity: props.tableReadWriteCapacity?.readCapacity,
         writeCapacity: props.tableReadWriteCapacity?.writeCapacity,
         billingMode: props.tableReadWriteCapacity ? BillingMode.PROVISIONED : BillingMode.PAY_PER_REQUEST,
+        removalPolicy: props.tableRemovalPolicy,
       });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,7 @@ export class Semaphore extends StateMachineFragment {
         readCapacity: props.tableReadWriteCapacity?.readCapacity,
         writeCapacity: props.tableReadWriteCapacity?.writeCapacity,
         billingMode: props.tableReadWriteCapacity ? BillingMode.PROVISIONED : BillingMode.PAY_PER_REQUEST,
-        removalPolicy: props.tableRemovalPolicy,
+        removalPolicy: props.tableRemovalPolicy ?? RemovalPolicy.DESTROY,
       });
     }
   }


### PR DESCRIPTION
This change allows someone to pass through a table RemovalPolicy for the Semaphore table. I noticed while using the library that the table sticks around even we remove this construct. I wouldn't expect it.

This way, I can explicitly pass `RemovalPolicy.DESTROY` if I want to.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*